### PR TITLE
Use nested categories in BudgetMonitoring

### DIFF
--- a/packages/Budget/BudgetMonitoring/description.txt
+++ b/packages/Budget/BudgetMonitoring/description.txt
@@ -12,7 +12,7 @@ Requires MMEX >= 1.6.2 (nested categories #1477)
 <h2>Budget has to be maintained</h2>
 
 It doesn't matter, if you maintain the budget on yearly or monthly basis. Every budget amount will be normalized
-to a monthly value, with a month having <code>30.41667</code> in average. This comes into play, if the period is 
+to a monthly value, with a month having <code>30.41667</code> days in average. This comes into play, if the period is 
 less than a month. I.e. if the period of a budget amount is <i>weekly</i> the budget amount will be divided by 
 <code>7</code> (value for one day) and multiplied by <code>30.41667</code> (value for the month).
 
@@ -32,7 +32,7 @@ expenses to actual incomes by clicking <em>vs Income</em> on the right side.
 <h3>Incomes and Expenses summary</h3>
 
 In the first section of the report you see the summary of both <em>Incomes</em> and <em>Expenses</em> over the selected
-time range. In each case the left side contains a radial bar of the percentaged actual value compared to the reference 
+time period. In each case the left side contains a radial bar of the percentaged actual value compared to the reference 
 value (budget) and the ride side contains the according amounts: reference value (budget), actual value and difference.
 
 The difference of the income will be calculated by <code>actual amount - budget amount</code>, whereas for expenses
@@ -45,7 +45,7 @@ of actual expenses vs actual incomes. You see the according radial bar chart min
 <h3>Incomes and Expenses by Category</h3>
 
 The second section of the report contains a tabular representation of the comparison of actuals vs budgets for 
-each category, which is contained in either the selected transactions or defined budgets. The percentage of 
+each main category, which is contained in either the selected transactions or defined budgets. The percentage of 
 the actuals compared to budgets will be displayed as little bar charts, additionally.
 
 To evaluate if a category is a income or expense category, respectively, the transaction codes 
@@ -53,24 +53,24 @@ To evaluate if a category is a income or expense category, respectively, the tra
 more <i>Deposit</i> transactions, the category is an expense category. If there are more <i>Withdrawal</i> transactions,
 it's an income category.
 
+Note: This means, that each main category and its nested categories should be used for either Withdrawals or Deposits.
+
 <h3>Colors and bars</h3>
 
 To visualize the percentage of actuals vs budgets colors will be used from dark green (<em>good</em>) to
 dark red (<em>bad</em>). The more actual income the greener the bar, but the more actual expenses the darker red is used.
 
 From 0% to 100% the background color is grey, so you can see, that the 100% is not reached yet. For values greater
-the 100% the background color stays green (which is used as 100%) and the bar starts again to grow in darker green 
+than 100% the background color stays green (which is used as 100%) and the bar starts again to grow in darker green 
 (for incomes) and yellow/ red (for expenses), respectively.
 
-<h3>Evaluation difference of budget and actual amounts</h3>
+<h3>Selected time period</h3>
 
-The budget amounts will be evaluated, if the first day of the month is contained in the time selection, whereas the
-actual amounts will only be evaluated if the very day of the transaction is contained in the time selection. So,
-if your time selection goes to 25th of a month, every transaction afterwards won't be contained within the report.
-If there is a budget value for an income or expense after the 25th, the budget value will be contained within the
-report nonetheless, as it's only assigned to the month and not to any day. 
+Regardless of what day of month you select as begin date or end date, the report will always select the first day of the 
+selected month as begin date and the last day of the selected month as end date. This is due to fact, that the budget
+is distributed evenly over all days of a month. 
 
-So, it makes sense to choose a time period which contains the last day of a month.
+Currently the report doesn't evaluate the start of the financial year.
 
 <h2>How to customize the contained data</h2>
 
@@ -101,7 +101,7 @@ ignoredAccountNames AS (
 
 <h3>Re-Assignment of transfer sub-categories</h3>
 
-You may have a sub category, which mostly transfer transactions are assigned to. Those transactions would be
+You may have a 1st-level nested category, which is mostly assigned to transfer transactions. Those transactions would be
 ignored, as the report doesn't contain transfer transactions. If the main category of this sub category is a
 <i>Withdrawal</i> or <i>Deposit</i> category, you can re-assign this sub category, so that the transactions will
 be used according to the transaction code of the main category:
@@ -112,16 +112,16 @@ transferSubCategoriesToReAssign AS (
 )
 </pre>
 
-<h3>Substitution of transfer sub-categories</h3>
+<h3>Substitution of nested transfer categories</h3>
 
-Some other transfer sub categories should be used as stand-alone expense or income category. For this you can use the
-sub query <code>transferSubCategoriesToSubstitute</code>:
+Some other transfer nested categories of any nested level should be used as stand-alone expense or income category. 
+For this you can use the sub query <code>transferSubCategoriesToSubstitute</code>:
 
 <pre>
 transferSubCategoriesToSubstitute AS (
-    SELECT 'My Main Category' transferCategoryName, 'My stand-alone Sub Category' transferSubCategoryName
+    SELECT 'My new Category' newCategoryName, 'My Main Category:1st-level-child-category:2nd-level-child-category' transferCategoryName
         , 'Deposit' transactionCode
 )
 </pre>
 
-In this case you would see <i>My stand-alone Sub Category</i> as separate, <em>virtual</em> Expense category within the report.
+In this case you would see <i>My new Category</i> as separate, <em>virtual</em> Expense category within the report.

--- a/packages/Budget/BudgetMonitoring/description.txt
+++ b/packages/Budget/BudgetMonitoring/description.txt
@@ -1,11 +1,13 @@
 <h1>Budget Monitoring Report</h1>
 
-Version: 2.0 - 20220328
+Version: 2.1 - 20220328
 
 The report monitors the actual incomes and expenses by main categories of the selected time range compared to the 
 maintained budget.
 
-The amounts of the sub categories are aggregated to the assigned main category of each sub category.
+The amounts of all nested categories of a main category are summed up to the according main category. 
+
+Requires MMEX >= 1.6.2 (nested categories #1477)
 
 <h2>Budget has to be maintained</h2>
 

--- a/packages/Budget/BudgetMonitoring/description.txt
+++ b/packages/Budget/BudgetMonitoring/description.txt
@@ -99,16 +99,16 @@ ignoredAccountNames AS (
     SELECT 'My secret account' accountName
 </pre>
 
-<h3>Re-Assignment of transfer sub-categories</h3>
+<h3>Re-Assignment of nested transfer categories</h3>
 
-You may have a 1st-level nested category, which is mostly assigned to transfer transactions. Those transactions would be
+You may have a nested category, which is mostly assigned to transfer transactions. Those transactions would be
 ignored, as the report doesn't contain transfer transactions. If the main category of this sub category is a
-<i>Withdrawal</i> or <i>Deposit</i> category, you can re-assign this sub category, so that the transactions will
+<i>Withdrawal</i> or <i>Deposit</i> category, you can re-assign this nested category, so that the transactions will
 be used according to the transaction code of the main category:
 
 <pre>
 transferSubCategoriesToReAssign AS (
-    SELECT 'My Main Category' CategoryName, 'My sub category of this Main Category' transferSubCategoryName
+    SELECT 'My Main Category:My sub category of this Main Category' transferCategoryName
 )
 </pre>
 

--- a/packages/Budget/BudgetMonitoring/description.txt
+++ b/packages/Budget/BudgetMonitoring/description.txt
@@ -1,6 +1,6 @@
 <h1>Budget Monitoring Report</h1>
 
-Version: 2.1 - 20220328
+Version: 2.1 - 20221230
 
 The report monitors the actual incomes and expenses by main categories of the selected time range compared to the 
 maintained budget.

--- a/packages/Budget/BudgetMonitoring/luacontent.lua
+++ b/packages/Budget/BudgetMonitoring/luacontent.lua
@@ -73,6 +73,11 @@ local baseCurrencySuffixSymbol = nil;
 local selectedAccounts = "all";
 
 ---
+-- Period of time which is contained in report
+-- 
+local selectedPeriod = '';
+
+---
 -- available types map withdrawal to expenses and deposit to incomes
 -- 
 local availableTypes = {
@@ -101,8 +106,10 @@ function handle_record(record)
 end
 
 function do_handle_record(record)
-    if (record:get("CategoryId") == nil or record:get("CategoryId") == "") then
+    if (record:get("TransCode") == "-- selected accounts --") then
         do_handle_accounts(record);
+    elseif (record:get("TransCode") == "-- selected period --") then
+        do_handle_period(record);
     else 
         do_handle_category(record);
     end
@@ -110,6 +117,10 @@ end
 
 function do_handle_accounts(record)
     selectedAccounts = record:get("Category");
+end
+
+function do_handle_period(record)
+    selectedPeriod = record:get("Category");
 end
 
 function do_handle_category(record)
@@ -298,6 +309,7 @@ function do_complete(result)
     local date = os.date("*t", os.time{year=os.date('%Y'), month=os.date('%m'), day=os.date('%d')});
     result:set("CREATED_AT", os.date("%c"));
     result:set("SELECTED_ACCOUNTS", selectedAccounts);
+    result:set("SELECTED_PERIOD", selectedPeriod);
     
     result:set("MONEY_STYLE", generateCurrencyCss());
     

--- a/packages/Budget/BudgetMonitoring/sqlcontent.sql
+++ b/packages/Budget/BudgetMonitoring/sqlcontent.sql
@@ -47,7 +47,7 @@ transferSubstitution AS (
  * SubCategories, which are used in transfer transactions, shoule be nonetheless assigned to the category
  */
 transferSubCategoriesToReAssign AS (
-    SELECT '<CategoryName>' CategoryName, '<TransferSubCategoryName>' transferSubCategoryName 
+    SELECT '<CategoryName>:<TransferSubCategoryName>' TransferCategoryName 
 ),
 /**
  * PeriodSelection: 
@@ -153,7 +153,7 @@ actuals AS (
     from (checkingaccount_v1 t
         left join SplitTransactions_v1 st on (t.TransId = st.TransId))
         join Categories c on (c.CategId = ifnull(st.CategId, t.CategId))
-        JOIN transferSubCategoriesToReAssign tsc ON (c.CategName = tsc.CategoryName || ':' || tsc.transferSubCategoryName)
+        JOIN transferSubCategoriesToReAssign tsc ON (c.CategName = tsc.TransferCategoryName)
         JOIN transactionTypesOfCategories ttc ON (c.RootCategId = ttc.CategoryId)
         join AccountList_v1 a on (t.AccountId = a.AccountId)
         join CurrencyFormats_v1 cf on (a.CurrencyId = cf.CurrencyId)

--- a/packages/Budget/BudgetMonitoring/sqlcontent.sql
+++ b/packages/Budget/BudgetMonitoring/sqlcontent.sql
@@ -31,17 +31,17 @@ ignoredAccountNames AS (
     SELECT '<accontNameToIgnore>' accountName 
 ),
 /**
- * Defines the sub-category referenced by tupel (category-name, sub-category-name) which should be used as 
- * category for the given transaction code (Withdrawal or Deposit). 
+ * Defines the nested-category referenced by '<root category-name>:<sub-category-name>[:<sub-sub-category-name>]) 
+ * which should be used as category for the given transaction code (Withdrawal or Deposit). 
  */
 transferSubCategoriesToSubstitute AS (
-    SELECT '<TransferCategoryName>' transferCategoryName, '<TransferSubCategoryName>' transferSubCategoryName
-        , '<TransactionCode>' transactionCode
+    SELECT '<TransferSubCategoryName>' newCategoryName, 
+        '<TransferCategoryName>:<TransferSubCategoryName>' transferCategoryName, '<TransactionCode>' transactionCode
 ),
 transferSubstitution AS (
-    select transferSubCategoryName categoryName, c.categId categoryId, transactionCode
+    select newCategoryName categoryName, c.categId categoryId, transactionCode
     from Categories c
-        join transferSubCategoriesToSubstitute sub on (c.categName = sub.transferCategoryName || ':' || sub.transferSubCategoryName)
+        join transferSubCategoriesToSubstitute sub on (c.categName = sub.transferCategoryName)
 ),
 /**
  * SubCategories, which are used in transfer transactions, shoule be nonetheless assigned to the category

--- a/packages/Budget/BudgetMonitoring/sqlcontent.sql
+++ b/packages/Budget/BudgetMonitoring/sqlcontent.sql
@@ -285,3 +285,10 @@ SELECT '-- selected accounts --' TransCode, "" CategoryId
     , "" BaseCurrencyPrefixSymbol, "" BaseCurrencySuffixSymbol, 0 SwitchType, '' TYPE
     , 0 Show
 FROM selectedAccounts
+UNION ALL
+SELECT '-- selected period --' TransCode, "" CategoryId
+    , begin_date || ' - ' || end_date Category
+    , 0 ActualAmount, 0 BudgetAmount, 0 Difference, 0 Rate, 0 RelativeDeviation
+    , "" BaseCurrencyPrefixSymbol, "" BaseCurrencySuffixSymbol, 0 SwitchType, '' TYPE
+    , 0 Show
+FROM PeriodSelection

--- a/packages/Budget/BudgetMonitoring/sqlcontent.sql
+++ b/packages/Budget/BudgetMonitoring/sqlcontent.sql
@@ -44,7 +44,7 @@ transferSubstitution AS (
         join transferSubCategoriesToSubstitute sub on (c.categName = sub.transferCategoryName)
 ),
 /**
- * SubCategories, which are used in transfer transactions, shoule be nonetheless assigned to the category
+ * SubCategories, which are used in transfer transactions, should be nonetheless assigned to the category
  */
 transferSubCategoriesToReAssign AS (
     SELECT '<CategoryName>:<TransferSubCategoryName>' TransferCategoryName 

--- a/packages/Budget/BudgetMonitoring/sqlcontent.sql
+++ b/packages/Budget/BudgetMonitoring/sqlcontent.sql
@@ -3,13 +3,25 @@
  *      This value will be used to calculate weekly, bi-weekly or daily budget for a month.
  */
 /**
+ * All nested categories with Id of the parent category and Id/ Name of the root category.
+ */
+WITH categories AS (
+    SELECT a.categid, a.categname, a.parentid, a.categid rootCategId, a.categName rootCategName 
+    FROM category_v1 a 
+    WHERE parentid = '-1' 
+    UNION ALL 
+    SELECT c.categid, r.categname || ':' || c.categname categName, c.parentid, r.rootCategId, r.rootCategName 
+    FROM categories r
+        join category_v1 c on (r.categid = c.parentid)
+),
+/**
  * Defines account types, which should not to be contained within the report. Several account types
  * can be combined with UNION ALL
  * You can list all used account types with 'select distinct accountType from AccountList_v1'
  * from the General Report Manager.
  */
-WITH ignoredAccountTypes AS (
-    SELECT '<accountTypeToIgnore>' accountType 
+ignoredAccountTypes AS (
+    SELECT '<accountTypeToIgnore>' accountType
 ),
 /**
  * Defines accounts by its account name, which should not to be contained within the report.
@@ -27,13 +39,9 @@ transferSubCategoriesToSubstitute AS (
         , '<TransactionCode>' transactionCode
 ),
 transferSubstitution AS (
-    select transferSubCategoryName categoryName, '0_' || sc.subCategId categoryId, transactionCode
-        , c.categId, sc.subCategId
-    from category_v1 c
-        join subcategory_v1 sc on (c.categId = sc.categId)
-        join transferSubCategoriesToSubstitute sub on (
-            c.categName = sub.transferCategoryName and sc.subCategName = sub.transferSubCategoryName
-        )
+    select transferSubCategoryName categoryName, c.categId categoryId, transactionCode
+    from Categories c
+        join transferSubCategoriesToSubstitute sub on (c.categName = sub.transferCategoryName || ':' || sub.transferSubCategoryName)
 ),
 /**
  * SubCategories, which are used in transfer transactions, shoule be nonetheless assigned to the category
@@ -102,12 +110,12 @@ transactionTypesOfCategories AS (
     from (
         select categId, categName, transcode, numberOfTransactions, max(numberOfTransactions) over (partition by categId, categName) numberOfTransactionsForMainTransCode
         from (
-            select transCode, categId, categName, count(transid) numberOfTransactions
-            from category_v1 
-                join checkingaccount_v1 using (categId)
+            select transCode, c.rootCategId categId, c.rootCategName categName, count(transid) numberOfTransactions
+            from categories c 
+                join checkingaccount_v1 ca on (c.categId = ca.categId)
             where 1=1
                 and transcode <> 'Transfer'
-            group by transcode, categId, categName
+            group by transcode, c.rootCategId, c.rootCategName
         )
     )
     where 1=1
@@ -123,13 +131,13 @@ transactionTypesOfCategories AS (
  *  * Transfer transactions, substituted as separate category
  */
 actuals AS (
-    select a.AccountName, ifnull(st.CategId, t.CategId) CategoryId, c.CategName category
+    select a.AccountName, c.RootCategId CategoryId, c.RootCategName category
         , ifnull(abs(st.SplitTransAmount), t.TransAmount) * cf.BaseConvRate BasedTransAmount
         , CASE WHEN t.TransCode = ttc.TransCode THEN 1 ELSE -1 END sign
     from (checkingaccount_v1 t
         left join SplitTransactions_v1 st on (t.TransId = st.TransId))
-        join Category_v1 c on (c.CategId = ifnull(st.CategId, t.CategId))
-        JOIN transactionTypesOfCategories ttc ON (c.CategId = ttc.CategoryId)
+        join Categories c on (c.CategId = ifnull(st.CategId, t.CategId))
+        JOIN transactionTypesOfCategories ttc ON (c.RootCategId = ttc.CategoryId)
         join AccountList_v1 a on (t.AccountId = a.AccountId)
         join CurrencyFormats_v1 cf on (a.CurrencyId = cf.CurrencyId)
     where 1=1
@@ -139,15 +147,14 @@ actuals AS (
         AND a.accountType NOT IN (SELECT accountType FROM IgnoredAccountTypes)
         AND a.accountName NOT IN (SELECT accountName FROM IgnoredAccountNames)
     UNION ALL
-    select a.AccountName, ifnull(st.CategId, t.CategId) CategoryId, c.CategName category
+    select a.AccountName, c.RootCategId CategoryId, c.RootCategName category
         , ifnull(abs(st.SplitTransAmount), t.TransAmount) * cf.BaseConvRate BasedTransAmount
         , 1 sign
     from (checkingaccount_v1 t
         left join SplitTransactions_v1 st on (t.TransId = st.TransId))
-        join Category_v1 c on (c.CategId = ifnull(st.CategId, t.CategId))
-        JOIN SubCategory_v1 sc ON (sc.SubCategId = ifnull(st.SubCategId, t.SubCategId))
-        JOIN transferSubCategoriesToReAssign tsc ON (c.CategName = tsc.CategoryName AND sc.SubCategName = tsc.transferSubCategoryName)
-        JOIN transactionTypesOfCategories ttc ON (c.CategId = ttc.CategoryId)
+        join Categories c on (c.CategId = ifnull(st.CategId, t.CategId))
+        JOIN transferSubCategoriesToReAssign tsc ON (c.CategName = tsc.CategoryName || ':' || tsc.transferSubCategoryName)
+        JOIN transactionTypesOfCategories ttc ON (c.RootCategId = ttc.CategoryId)
         join AccountList_v1 a on (t.AccountId = a.AccountId)
         join CurrencyFormats_v1 cf on (a.CurrencyId = cf.CurrencyId)
     where 1=1
@@ -162,10 +169,10 @@ actuals AS (
         , 1 sign
     from (checkingaccount_v1 t
         left join SplitTransactions_v1 st on (t.TransId = st.TransId))
-        join Category_v1 c on (c.CategId = ifnull(st.CategId, t.CategId))
+        join Categories c on (c.CategId = ifnull(st.CategId, t.CategId))
         join AccountList_v1 a on (t.AccountId = a.AccountId)
         join CurrencyFormats_v1 cf on (a.CurrencyId = cf.CurrencyId)
-        JOIN transferSubstitution ts ON (ts.CategId = ifnull(st.CategId, t.CategId) AND ts.SubCategId = ifnull(st.SubCategId, t.SubCategId))
+        JOIN transferSubstitution ts ON (ts.CategoryId = c.categId)
     WHERE 1=1
         AND t.TransCode = 'Transfer'
         AND t.Status <> 'V'
@@ -185,50 +192,42 @@ actualsByCategory AS (
 /**
  * Budget totals by category normalized to months
  */
-budgetsByCategory AS (
-    select c.CategId CategoryId, c.CategName Category
-        , round(total(abs(
-            case 
-                when Period = 'Weekly' then Amount * 30.41667 / 7
-                when Period = 'Bi-Weekly' then Amount * 30.41667 / 7 / 2
-                when Period = 'Fortnightly' then Amount * 30.41667 / 7 / 2
-                when Period = 'Monthly' then Amount 
-                when Period = 'Bi-Monthly' then Amount / 2
-                when Period = 'Every 2 Months' then Amount / 2
-                when Period = 'Quarterly' then Amount / 3
-                when Period = 'Half-Yearly' then Amount / 6
-                when Period = 'Yearly' then Amount / 12
-                when Period = 'Daily' then Amount * 30.41667
-                WHEN Period = 'None' THEN 0
-            end
-        )), 2) BudgetAmount
+Budgets as (
+    select bt.BudgetYearId, bt.CategId, Period
+        , case 
+              when Period = 'Weekly' then 30.41667 / 7
+              when Period = 'Bi-Weekly' then 30.41667 / 7 / 2
+              when Period = 'Fortnightly' then 30.41667 / 7 / 2
+              when Period = 'Monthly' then 1 
+              when Period = 'Bi-Monthly' then 1 / 2
+              when Period = 'Every 2 Months' then 1 / 2
+              when Period = 'Quarterly' then 1 / 3
+              when Period = 'Half-Yearly' then 1 / 6
+              when Period = 'Yearly' then 1 / 12
+              when Period = 'Daily' then 30.41667
+              WHEN Period = 'None' THEN 0
+          end Factor
+        , Amount
     from BudgetTable_v1 bt
-        join selectedBudgetMonths sbm on (bt.BudgetYearId = sbm.BudgetYearId)
-        join Category_v1 c on (bt.CategId = c.CategId)
-        left join SubCategory_v1 sc on (bt.SubCategId = sc.SubCategId)
-    group by c.CategId, c.CategName
-    UNION ALL
-    SELECT ts.CategoryId, ts.CategoryName Category
-        , round(total(abs(
-            case 
-                when Period = 'Weekly' then Amount * 30.41667 / 7
-                when Period = 'Bi-Weekly' then Amount * 30.41667 / 7 / 2
-                when Period = 'Fortnightly' then Amount * 30.41667 / 7 / 2
-                when Period = 'Monthly' then Amount 
-                when Period = 'Bi-Monthly' then Amount / 2
-                when Period = 'Every 2 Months' then Amount / 2
-                when Period = 'Quarterly' then Amount / 3
-                when Period = 'Half-Yearly' then Amount / 6
-                when Period = 'Yearly' then Amount / 12
-                when Period = 'Daily' then Amount * 30.41667
-                WHEN Period = 'None' THEN 0
-            end
-        )), 2) BudgetAmount
-    FROM BudgetTable_v1 bt
-        join selectedBudgetMonths sbm on (bt.BudgetYearId = sbm.BudgetYearId)
-        JOIN transferSubstitution ts ON (ts.CategId = bt.CategId AND ts.SubCategId = bt.SubCategId)
-    GROUP BY ts.CategoryId, ts.CategoryName
+        join SelectedBudgetMonths sbm on (bt.BudgetYearId = sbm.BudgetYearId)
 ),
+/**
+ * Budget totals by category normalized to months
+ */
+budgetsByCategory AS (
+    select CategoryId, Category
+        , round(total(abs(Amount * Factor)), 2) BudgetAmount
+    from (
+        select CategId, RootCategId CategoryId, RootCategName Category
+        from Categories
+        union all 
+        SELECT CategoryId CategId, CategoryId, CategoryName Category
+        from transferSubstitution
+    ) c 
+        join Budgets b on (c.CategId = b.CategId)
+    group by CategoryId, Category
+),
+--    GROUP BY ts.CategoryId, ts.CategoryName
 /**
  * actuals vs budgets for each category if one of the values exists
  */
@@ -272,8 +271,8 @@ reportData AS (
         , BaseCurrencyPrefixSymbol
         , BaseCurrencySuffixSymbol
         , 0 SwitchType
-        , '' TYPE
-        , 1 Show
+        , '' Type
+    , 1 Show
     from actualsVsBudgets
     order by TransCode, Category
 )

--- a/packages/Budget/BudgetMonitoring/sqlcontent.sql
+++ b/packages/Budget/BudgetMonitoring/sqlcontent.sql
@@ -275,6 +275,19 @@ reportData AS (
     , 1 Show
     from actualsVsBudgets
     order by TransCode, Category
+),
+/**
+ * Substitute date format patterns, which work in C++ but not in SQLite
+ */
+DateFormatSubstituted AS (
+    SELECT replace(replace(replace(infovalue, 
+        '%y', '%Y'), 
+        '%Mon', '%m'), 
+        '%w', '') format
+        , infovalue, infoname
+    FROM infotable_v1
+    WHERE infoname = 'DATEFORMAT'
+    LIMIT 1
 )
 SELECT *
 FROM reportData
@@ -287,8 +300,9 @@ SELECT '-- selected accounts --' TransCode, "" CategoryId
 FROM selectedAccounts
 UNION ALL
 SELECT '-- selected period --' TransCode, "" CategoryId
-    , begin_date || ' - ' || end_date Category
+    , strftime(ifnull(format, '%y-%m-%d'), begin_date) || ' - ' || strftime(ifnull(format, '%y-%m-%d'), end_date) Category
     , 0 ActualAmount, 0 BudgetAmount, 0 Difference, 0 Rate, 0 RelativeDeviation
     , "" BaseCurrencyPrefixSymbol, "" BaseCurrencySuffixSymbol, 0 SwitchType, '' TYPE
     , 0 Show
 FROM PeriodSelection
+    left join DateFormatSubstituted on (1=1)

--- a/packages/Budget/BudgetMonitoring/template.htt
+++ b/packages/Budget/BudgetMonitoring/template.htt
@@ -40,6 +40,7 @@
         <header><h2>Budget Dashboard</h2></header>
         <aside>
             <p>Report created <TMPL_VAR NAME="CREATED_AT" /></p>
+            <p>Selected Time Period: <TMPL_VAR NAME="SELECTED_PERIOD" /></p>
         </aside>
         <footer>Accounts: <TMPL_VAR NAME="SELECTED_ACCOUNTS" /></footer>
     </div>


### PR DESCRIPTION
The BudgetMonitoring report now uses nested categories, which are stored as adjacency list since MMEX 1.6.2.

* nested transfer categories of any level can be substituted
* nested transfer categories of any level can be re-assigned

Additionally the report now prints the time period in the report header, which is used to selectd the data.

BTW: perhaps it makes sense, to tag the one commit, which contains all reports compatible to the DB schema of version 1.6.1 and below.